### PR TITLE
Corrected url to UcoSLAM web page.

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -16,7 +16,7 @@ look at [this draft paper](media/tagslam.pdf).
 If you have a standard visual SLAM problem and want to use fiducial markers,
 you should probably *NOT* use TagSLAM because there are packages
 out there that are better suited. Consider for instance
-using [UcoSLAM](http://ucoslam.com) (disclosure: I haven't actually
+using [UcoSLAM](https://www.uco.es/investiga/grupos/ava/portfolio/ucoslam/) (disclosure: I haven't actually
 used it yet). It runs in real-time, and uses keyframes, which should
 make it scale to larger trajectories. Unlike TagSLAM, it can use both,
 features in the wild, and tags for loop closure, not just tags. It's a

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@ look at <a href="media/tagslam.pdf">this draft paper</a>.</p>
 <p>If you have a standard visual SLAM problem and want to use fiducial markers,
 you should probably <em>NOT</em> use TagSLAM because there are packages
 out there that are better suited. Consider for instance
-using <a href="http://ucoslam.com">UcoSLAM</a> (disclosure: I haven&rsquo;t actually
+using <a href="https://www.uco.es/investiga/grupos/ava/portfolio/ucoslam/">UcoSLAM</a> (disclosure: I haven&rsquo;t actually
 used it yet). It runs in real-time, and uses keyframes, which should
 make it scale to larger trajectories. Unlike TagSLAM, it can use both,
 features in the wild, and tags for loop closure, not just tags. It&rsquo;s a


### PR DESCRIPTION
The http://ucoslam.com link is no longer correct, this PR changes it to https://www.uco.es/investiga/grupos/ava/portfolio/ucoslam/.